### PR TITLE
fix modal bug on iOS and update maps API key

### DIFF
--- a/ScoutDesign/library/Widgets/Modal/Modal.tsx
+++ b/ScoutDesign/library/Widgets/Modal/Modal.tsx
@@ -114,8 +114,8 @@ const ModalBase = ({
 const Modal = ({visible, escape, onNext, children, ...rest}: ModalProps) => {
   let next = onNext
     ? () => {
-        onNext();
         escape();
+        onNext();
       }
     : undefined;
 

--- a/app.json
+++ b/app.json
@@ -64,7 +64,7 @@
       "iosDisplayInForeground": true
     },
     "extra": {
-      "GOOGLE_MAPS_API_KEY": "AIzaSyCy38WoJFJEn3gr7EEc1OAWcO-Xsslilbs",
+      "GOOGLE_MAPS_API_KEY": "AIzaSyAm4mWIlZ42Y4Ww-nR7ehQt6Z2i-aSlyeU",
       "eas": {
         "projectId": "053431a1-924d-475e-baec-77fa89064c5a"
       }


### PR DESCRIPTION
Close modal before handling state logic to fix modal not disappearing on iOS.

Also for some reason the Google Maps API key did not match the one associated with the Google Cloud, so we updated it.