### PR TITLE
add check on event creation

### DIFF
--- a/src/modules/createEvent/CreateEvent.tsx
+++ b/src/modules/createEvent/CreateEvent.tsx
@@ -86,8 +86,27 @@ const CreateEvent = ({ navigation, route }: CreateEventProps) => {
 
   const schema = data['eventSchemas'][route.params.type.toLowerCase()];
 
+  function hasAllEventDetails(eventData: any) {
+    return (
+      eventData.date &&
+      eventData.description &&
+      eventData.distance &&
+      eventData.endTime &&
+      eventData.location &&
+      eventData.startTime &&
+      eventData.title &&
+      eventData.uniqueMeetLocation
+    );
+  }
+
   const createEvent = () => {
     const eventDataCopy = { ...fields };
+
+    if (!hasAllEventDetails(eventDataCopy)) {
+      alert('missing required event details');
+      return;
+    }
+
     if (route.params.update) {
       const omitInvalidFields = (key, value) => {
         if (key === '__typename') {
@@ -155,7 +174,8 @@ const CreateEvent = ({ navigation, route }: CreateEventProps) => {
       back={() => {
         dispatch && dispatch(clearEventForm());
         navigation.goBack();
-      }}>
+      }}
+    >
       {/* Schema representing all the types of events currently in the app. This
       comes from the server 
       TODO: gql form schema rewrite: update with the new form types */}


### PR DESCRIPTION
# Description

Add check on event creation to make sure all details are filled out. Before, user would be able to create event with missing fields which resulted in null related bug when accessing event after creation.

## Figma Designs

Include a link to the Figma design here if neccesary.

- [x] Approved by designer

## Screenshots/Video

Include screenshots of added features/bugfixes if neccesary.
<img width="1440" alt="Screenshot 2023-04-16 at 4 44 55 PM" src="https://user-images.githubusercontent.com/32346117/232341183-ceded5f4-7686-437e-a550-dc181d0adf83.png">

